### PR TITLE
adding TracingConfig for unmarshalling the configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -55,3 +55,12 @@ type TraceConfig struct {
 	HeaderConfig  HeaderConfig
 	TraceProvider trace.TracerProvider
 }
+
+// TracingConfig represents a component for tracing. It will be used to unmarshal
+// the configuration provided in application.yaml file.
+type TracingConfig struct {
+	// Provider describe the configuration for this application..
+	Provider Config
+	// Headers  is the header name  configuration for this application.
+	Headers HeaderConfig
+}

--- a/config.go
+++ b/config.go
@@ -59,7 +59,7 @@ type TraceConfig struct {
 // TracingConfig represents a component for tracing. It will be used to unmarshal
 // the configuration provided in application.yaml file.
 type TracingConfig struct {
-	// Provider describe the configuration for this application..
+	// Provider describe the configuration for this application.
 	Provider Config
 	// Headers  is the header name  configuration for this application.
 	Headers HeaderConfig


### PR DESCRIPTION
TracingConfig will be used by clients to unmarshal the configuration from the properties file, it will be used in Petasos, Tr1d1um, Scytale, Caduceus, Talaria, Themis, and Argus.