### PR TITLE
Issue: the response was having multiple headers of same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Add struct to unmarshal tracing info. [#19](https://github.com/xmidt-org/candlelight/pull/19) thanks to @Sachin4403
 
+### Fixed
+- TraceMiddleware was adding TraceID and SpanID to the response due to which we were seeing same traceID and multiple spanID in response, Now it will be adding the TraceID and SpanID only when the remote span is not present in context. [#21](https://github.com/xmidt-org/candlelight/pull/21) thanks to @Sachin4403
 
 ## [v0.0.2]
 - Added setup and middleware for application tracing using opentelemetry. [#16](https://github.com/xmidt-org/candlelight/pull/16) thanks to @Sachin4403


### PR DESCRIPTION
In HTTP response Trace and span, information was added multiple times. to avoid this adding the trace and span information at the initial stage of starting the otel span.

```
trace.RemoteSpanContextFromContext(Ctx) 
```

will return the remote span or noop span, if it is a noop span then we are sure the span is started in this service only so adding the trace information in response headers