### PR TITLE
Fix linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,4 @@
 ---
-linters-settings:
-  misspell:
-    locale: US
-
 linters:
   enable:
     - bodyclose
@@ -26,6 +22,8 @@ issues:
         - funlen
 
 linters-settings:
+  misspell:
+    locale: US
   errorlint:
     # Report non-wrapping error creation using fmt.Errorf
     errorf: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.0.11]
 - Updated tracer, relaxed return type in function within Tracer.go [#60](https://github.com/xmidt-org/candlelight/pull/60)
 
 ## [v0.0.10]
 - Update to use otel v1.7.0. [#44](https://github.com/xmidt-org/candlelight/pull/44)
 - Update to use use common workflows for simplicity. [#45](https://github.com/xmidt-org/candlelight/pull/45)
 - Update the dependencies to the latest. [#46](https://github.com/xmidt-org/candlelight/pull/46)
-
 
 ## [v0.0.9]
 - Moved GenTID function from transaction package to candlelight. [#38](https://github.com/xmidt-org/candlelight/pull/38)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update to use use common workflows for simplicity. [#45](https://github.com/xmidt-org/candlelight/pull/45)
 - Update the dependencies to the latest. [#46](https://github.com/xmidt-org/candlelight/pull/46)
 
+
 ## [v0.0.9]
 - Moved GenTID function from transaction package to candlelight. [#38](https://github.com/xmidt-org/candlelight/pull/38)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [v0.0.11]
 - Updated tracer, relaxed return type in function within Tracer.go [#60](https://github.com/xmidt-org/candlelight/pull/60)
 
 ## [v0.0.10]


### PR DESCRIPTION
Fix linter configuration file issues. The `linter-settings` section was included twice and was causing the linter to fail. 