### PR TITLE
Update Tracer and Linter File Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.0.11]
+- Fixed malformed linter config [62](https://github.com/xmidt-org/candlelight/pull/62)
 - Updated tracer, relaxed return type in function within Tracer.go [#60](https://github.com/xmidt-org/candlelight/pull/60)
 
 ## [v0.0.10]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [v0.0.11]
-- Fixed malformed linter config [62](https://github.com/xmidt-org/candlelight/pull/62)
+- Fixed malformed linter config [#62](https://github.com/xmidt-org/candlelight/pull/62)
 - Updated tracer, relaxed return type in function within Tracer.go [#60](https://github.com/xmidt-org/candlelight/pull/60)
 
 ## [v0.0.10]


### PR DESCRIPTION
- Fixed malformed linter config https://github.com/xmidt-org/candlelight/pull/62

- Updated tracer, relaxed return type in function within Tracer.go https://github.com/xmidt-org/candlelight/pull/60