### PR TITLE
Update Tracing Middleware to not return trace info in header

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -100,12 +100,6 @@ func EchoFirstTraceNodeInfo(propagator propagation.TextMapPropagator, isDecodabl
 			}
 
 			ctx = propagation.TraceContext{}.Extract(ctx, tmp)
-
-			sc := trace.SpanContextFromContext(ctx)
-			if sc.IsValid() {
-				w.Header().Set(spanIDHeaderName, sc.SpanID().String())
-				w.Header().Set(traceIDHeaderName, sc.TraceID().String())
-			}
 			delegate.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}


### PR DESCRIPTION
Closes #143 
The new behavior is that neither `tracestate` nor `traceparent` will be returned in the header. This will help the the return be more concise as the request goes through multiple servers.