### PR TITLE
Fix the lint errors due to deprecation.

### DIFF
--- a/tracerProvider.go
+++ b/tracerProvider.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/jaeger"
+	"go.opentelemetry.io/otel/exporters/jaeger" // nolint:staticcheck
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	stdout "go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
@@ -33,6 +33,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 var (
@@ -223,6 +224,6 @@ var providersConfig = map[string]ProviderConstructor{
 		return tp, nil
 	},
 	"noop": func(config Config, smplr sdktrace.Sampler) (trace.TracerProvider, error) {
-		return trace.NewNoopTracerProvider(), nil
+		return noop.NewTracerProvider(), nil
 	},
 }

--- a/tracerProvider_test.go
+++ b/tracerProvider_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestConfigureTracerProvider(t *testing.T) {
@@ -188,7 +189,7 @@ func TestConfigureTracerProvider(t *testing.T) {
 				Provider: "coolest",
 				Providers: map[string]ProviderConstructor{
 					"coolest": func(_ Config, _ sdktrace.Sampler) (trace.TracerProvider, error) {
-						return trace.NewNoopTracerProvider(), nil
+						return noop.NewTracerProvider(), nil
 					},
 				},
 			},

--- a/tracingFactory.go
+++ b/tracingFactory.go
@@ -3,6 +3,7 @@ package candlelight
 import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // New creates a structure with components that apps can use to initialize OpenTelemetry
@@ -28,14 +29,14 @@ type Tracing struct {
 
 // IsNoop returns true if the tracer provider component is a noop. False otherwise.
 func (t Tracing) IsNoop() bool {
-	return t.TracerProvider() == trace.NewNoopTracerProvider()
+	return t.TracerProvider() == noop.NewTracerProvider()
 }
 
 // TracerProvider returns the tracer provider component. By default, the noop
 // tracer provider is returned.
 func (t Tracing) TracerProvider() trace.TracerProvider {
 	if t.tracerProvider == nil {
-		return trace.NewNoopTracerProvider()
+		return noop.NewTracerProvider()
 	}
 	return t.tracerProvider
 }


### PR DESCRIPTION
- trace.NewNoopTracerProvider changes to noop.NewTracerProvider
- go.opentelemetry.io/otel/exporters/jaeger is marked as deprecated but for now this library is ignoring that change.  An issue will be filed to handle this separately.