### PR TITLE
Make Tracing Headers Configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	// NoParent = "never" (default), root spans are not initiated
 	// NoParent = "always", roots spans are initiated
 	NoParent string `json:"noParent"`
+
+	// HeaderPrefix allows the client to specify the header relevant to their application's trace information
+	HeaderPrefix string `json:"HeaderPrefix"`
 }
 
 // TraceConfig will be used in TraceMiddleware to use config and TraceProvider

--- a/middleware.go
+++ b/middleware.go
@@ -57,8 +57,8 @@ func EchoFirstTraceNodeInfo(tracing Tracing, isDecodable bool) func(http.Handler
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 			var ctx context.Context
-			var headerPrefix = tracing.headerPrefix
-			var propagator = tracing.propagator
+			headerPrefix := tracing.headerPrefix
+			propagator := tracing.propagator
 
 			if isDecodable {
 				if req, err := wrphttp.DecodeRequest(r, nil); err == nil {

--- a/middleware.go
+++ b/middleware.go
@@ -52,11 +52,13 @@ func (traceConfig *TraceConfig) TraceMiddleware(delegate http.Handler) http.Hand
 // EchoFirstNodeTraceInfo captures the trace information from a request, writes it
 // back in the response headers, and adds it to the request's context
 // It can also decode the request and save the resulting WRP object in the context if isDecodable is true
-func EchoFirstTraceNodeInfo(propagator propagation.TextMapPropagator, isDecodable bool) func(http.Handler) http.Handler {
+func EchoFirstTraceNodeInfo(tracing Tracing, isDecodable bool) func(http.Handler) http.Handler {
 	return func(delegate http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 			var ctx context.Context
+			var headerPrefix = tracing.headerPrefix
+			var propagator = tracing.propagator
 
 			if isDecodable {
 				if req, err := wrphttp.DecodeRequest(r, nil); err == nil {
@@ -68,7 +70,7 @@ func EchoFirstTraceNodeInfo(propagator propagation.TextMapPropagator, isDecodabl
 			ctx = propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 			if msg, ok := wrpcontext.GetMessage(ctx); ok {
 				traceHeaders = msg.Headers
-			} else if headers := r.Header.Values("X-Xmidt-Headers"); len(headers) != 0 {
+			} else if headers := r.Header.Values(headerPrefix); len(headers) != 0 {
 				traceHeaders = headers
 			}
 

--- a/tracerProvider.go
+++ b/tracerProvider.go
@@ -24,10 +24,10 @@ import (
 )
 
 var (
-	ErrTracerProviderNotFound    = errors.New("TracerProvider builder could not be found")
-	ErrTracerProviderBuildFailed = errors.New("Failed building TracerProvider")
-	ErrInvalidParentBasedValue   = errors.New("Invalid ParentBased value provided in configuration")
-	ErrInvalidNoParentValue      = errors.New("Invalid No Parent value provided in configuration")
+	ErrTracerProviderNotFound    = errors.New("tracerProvider builder could not be found")
+	ErrTracerProviderBuildFailed = errors.New("failed building TracerProvider")
+	ErrInvalidParentBasedValue   = errors.New("invalid ParentBased value provided in configuration")
+	ErrInvalidNoParentValue      = errors.New("invalid No Parent value provided in configuration")
 )
 
 // DefaultTracerProvider is used when no provider is given.

--- a/tracingFactory.go
+++ b/tracingFactory.go
@@ -13,7 +13,8 @@ import (
 // tracing instrumentation code.
 func New(config Config) (Tracing, error) {
 	var tracing = Tracing{
-		propagator: propagation.TraceContext{},
+		propagator:   propagation.TraceContext{},
+		headerPrefix: config.HeaderPrefix,
 	}
 	tracerProvider, err := ConfigureTracerProvider(config)
 	if err != nil {
@@ -28,6 +29,7 @@ func New(config Config) (Tracing, error) {
 type Tracing struct {
 	tracerProvider trace.TracerProvider
 	propagator     propagation.TextMapPropagator
+	headerPrefix   string
 }
 
 // IsNoop returns true if the tracer provider component is a noop. False otherwise.


### PR DESCRIPTION
- Previously, tracing headers were hardcoded in the middler function as `X-Xmidt-Headers`
- To better Candlelight's reusability (and have it get along with Nion), this was changed to be a configurable variable 
- Also fixed some small linter complaints 

Closes #287 